### PR TITLE
feat: add status connect and lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GoDoc](https://godoc.org/github.com/electric-saw/ccloud-client-go?status.svg)](https://godoc.org/github.com/electric-saw/ccloud-client-go)
 [![License](https://img.shields.io/github/license/electric-saw/ccloud-client-go)](LICENSE)
 
-A comprehensive Go client library for Confluent Cloud API. This library enables developers to programmatically manage Confluent Cloud resources including Kafka clusters, environments, service accounts, client quotas, and more.
+A comprehensive Go client library for Confluent Cloud API. This library enables developers to programmatically manage Confluent Cloud resources including Kafka clusters, environments, service accounts, client quotas, connectors, and more.
 
 ## Features
 
@@ -12,6 +12,7 @@ A comprehensive Go client library for Confluent Cloud API. This library enables 
 - **Kafka Cluster Management**: Provision and manage Kafka clusters
 - **Service Account Management**: Create and manage service accounts and API keys
 - **Client Quota Management**: Define and control resource quotas for clients
+- **Connector Management**: Create, configure, monitor, and manage Kafka connectors with lifecycle control
 - **Schema Registry Integration**: Manage schemas and subjects
 - **RBAC Support**: Role-based access control operations
 - **Cluster Linking**: Configure and manage cluster linking
@@ -114,6 +115,82 @@ updatedQuota, err := client.UpdateClientQuota(quota.ID, updateReq)
 
 // Delete a client quota
 err = client.DeleteClientQuota(quota.ID)
+```
+
+## Working with Connectors
+
+### Creating a Connector
+
+```go
+// Create an S3 Sink Connector
+s3Config := &ccloud.S3SinkConnectorConfig{
+    ConnectorClass:        "S3_SINK",
+    Bucket:                "my-s3-bucket",
+    AuthenticationMethod:  "IAM Roles",
+    ProviderIntegrationId: "pi-12345",
+    Topics:                "my-topic",
+    InputDataFormat:       "AVRO",
+    OutputDataFormat:      "AVRO",
+    TasksMax:              "2",
+}
+
+connector, err := client.CreateConnector("env-xyz789", "lkc-abc123", "my-s3-connector", s3Config)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("Connector created: %s\n", connector.Name)
+```
+
+### Managing Connector Lifecycle
+
+```go
+// Get connector details
+connector, err := client.GetConnector("env-xyz789", "lkc-abc123", "my-s3-connector")
+
+// Get connector status
+status, err := client.GetConnectorStatus("env-xyz789", "lkc-abc123", "my-s3-connector")
+fmt.Printf("Connector status: %s\n", status.Connector.State)
+
+// Pause a connector
+err = client.PauseConnector("env-xyz789", "lkc-abc123", "my-s3-connector")
+
+// Resume a connector
+err = client.ResumeConnector("env-xyz789", "lkc-abc123", "my-s3-connector")
+
+// Restart a connector
+err = client.RestartConnector("env-xyz789", "lkc-abc123", "my-s3-connector")
+
+// List all connectors
+connectors, err := client.ListConnectors("env-xyz789", "lkc-abc123")
+
+// Update connector configuration
+newConfig := &ccloud.S3SinkConnectorConfig{
+    TasksMax: "4",
+}
+
+updatedConnector, err := client.UpdateConnectorConfig("env-xyz789", "lkc-abc123", "my-s3-connector", newConfig)
+
+// Delete a connector
+err = client.DeleteConnector("env-xyz789", "lkc-abc123", "my-s3-connector")
+```
+
+### Understanding Connector Status
+
+The connector status provides detailed information about the connector and its tasks:
+
+```go
+status, err := client.GetConnectorStatus("env-xyz789", "lkc-abc123", "my-s3-connector")
+
+// Check connector state
+if status.Connector.State == "RUNNING" {
+    fmt.Println("Connector is running")
+}
+
+// Check individual task status
+for _, task := range status.Tasks {
+    fmt.Printf("Task %d: %s\n", task.Id, task.State)
+}
 ```
 
 ## Additional Examples

--- a/ccloud/connectors.go
+++ b/ccloud/connectors.go
@@ -57,9 +57,9 @@ type TransformsConfig struct {
 }
 
 type ConnectorStatus struct {
-	Name      string      `json:"name"`
+	Name      string              `json:"name"`
 	Connector ConnectorTaskStatus `json:"connector"`
-	Tasks     []TaskStatus `json:"tasks"`
+	Tasks     []TaskStatus        `json:"tasks"`
 }
 
 type ConnectorTaskStatus struct {

--- a/ccloud/connectors.go
+++ b/ccloud/connectors.go
@@ -56,6 +56,25 @@ type TransformsConfig struct {
 	OffsetField    string
 }
 
+type ConnectorStatus struct {
+	Name      string      `json:"name"`
+	Connector ConnectorTaskStatus `json:"connector"`
+	Tasks     []TaskStatus `json:"tasks"`
+}
+
+type ConnectorTaskStatus struct {
+	State    string `json:"state"`
+	WorkerId string `json:"worker_id"`
+	Trace    string `json:"trace,omitempty"`
+}
+
+type TaskStatus struct {
+	Id       int    `json:"id"`
+	State    string `json:"state"`
+	WorkerId string `json:"worker_id"`
+	Trace    string `json:"trace,omitempty"`
+}
+
 func applyDefaults(configMap map[string]interface{}, config interface{}) {
 	v := reflect.ValueOf(config)
 	if v.Kind() == reflect.Ptr {
@@ -213,6 +232,28 @@ func (c *ConfluentClient) GetConnector(environmentId, clusterId, connectorName s
 	return &connector, nil
 }
 
+func (c *ConfluentClient) GetConnectorStatus(environmentId, clusterId, connectorName string) (*ConnectorStatus, error) {
+	urlPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/status", environmentId, clusterId, connectorName)
+	req, err := c.doRequest(urlPath, http.MethodGet, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if http.StatusOK != req.StatusCode {
+		return nil, fmt.Errorf("failed to get connector status: %s", req.Status)
+	}
+
+	defer req.Body.Close()
+
+	var status ConnectorStatus
+	err = json.NewDecoder(req.Body).Decode(&status)
+	if err != nil {
+		return nil, err
+	}
+
+	return &status, nil
+}
+
 func (c *ConfluentClient) DeleteConnector(environmentId, clusterId, connectorName string) error {
 	urlPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s", environmentId, clusterId, connectorName)
 	req, err := c.doRequest(urlPath, http.MethodDelete, nil, nil)
@@ -222,6 +263,48 @@ func (c *ConfluentClient) DeleteConnector(environmentId, clusterId, connectorNam
 
 	if http.StatusOK != req.StatusCode && http.StatusNoContent != req.StatusCode && http.StatusAccepted != req.StatusCode {
 		return fmt.Errorf("failed to delete connector: %s", req.Status)
+	}
+
+	return nil
+}
+
+func (c *ConfluentClient) PauseConnector(environmentId, clusterId, connectorName string) error {
+	urlPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/pause", environmentId, clusterId, connectorName)
+	req, err := c.doRequest(urlPath, http.MethodPut, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if http.StatusOK != req.StatusCode && http.StatusAccepted != req.StatusCode {
+		return fmt.Errorf("failed to pause connector: %s", req.Status)
+	}
+
+	return nil
+}
+
+func (c *ConfluentClient) ResumeConnector(environmentId, clusterId, connectorName string) error {
+	urlPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/resume", environmentId, clusterId, connectorName)
+	req, err := c.doRequest(urlPath, http.MethodPut, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if http.StatusOK != req.StatusCode && http.StatusAccepted != req.StatusCode {
+		return fmt.Errorf("failed to resume connector: %s", req.Status)
+	}
+
+	return nil
+}
+
+func (c *ConfluentClient) RestartConnector(environmentId, clusterId, connectorName string) error {
+	urlPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/restart", environmentId, clusterId, connectorName)
+	req, err := c.doRequest(urlPath, http.MethodPost, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if http.StatusOK != req.StatusCode && http.StatusAccepted != req.StatusCode {
+		return fmt.Errorf("failed to restart connector: %s", req.Status)
 	}
 
 	return nil

--- a/ccloud/connectors_test.go
+++ b/ccloud/connectors_test.go
@@ -301,3 +301,206 @@ func TestUpdateConnectorTyped(t *testing.T) {
 	assert.Equal(t, s3Config.Bucket, updated.Config["s3.bucket.name"])
 	assert.Equal(t, "S3_SINK", updated.Config["connector.class"])
 }
+
+func TestGetConnectorStatus(t *testing.T) {
+	env := "env-1"
+	cluster := "cluster-1"
+	name := "test-connector"
+
+	expectedStatus := ConnectorStatus{
+		Name: name,
+		Connector: ConnectorTaskStatus{
+			State:    "RUNNING",
+			WorkerId: "worker-1",
+		},
+		Tasks: []TaskStatus{
+			{
+				Id:       0,
+				State:    "RUNNING",
+				WorkerId: "worker-1",
+			},
+			{
+				Id:       1,
+				State:    "RUNNING",
+				WorkerId: "worker-1",
+			},
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		expectedPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/status", env, cluster, name)
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: %s (expect %s)", r.URL.Path, expectedPath)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(expectedStatus)
+	}))
+	defer ts.Close()
+
+	client := NewClient().WithAuth(noopAuth{}).WithBaseUrl(ts.URL)
+
+	status, err := client.GetConnectorStatus(env, cluster, name)
+	assert.NoError(t, err)
+	assert.Equal(t, name, status.Name)
+	assert.Equal(t, "RUNNING", status.Connector.State)
+	assert.Equal(t, "worker-1", status.Connector.WorkerId)
+	assert.Len(t, status.Tasks, 2)
+	assert.Equal(t, "RUNNING", status.Tasks[0].State)
+	assert.Equal(t, "RUNNING", status.Tasks[1].State)
+}
+
+func TestPauseConnector(t *testing.T) {
+	env := "env-1"
+	cluster := "cluster-1"
+	name := "test-connector"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		expectedPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/pause", env, cluster, name)
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: %s (expect %s)", r.URL.Path, expectedPath)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewClient().WithAuth(noopAuth{}).WithBaseUrl(ts.URL)
+
+	err := client.PauseConnector(env, cluster, name)
+	assert.NoError(t, err)
+}
+
+func TestPauseConnectorAccepted(t *testing.T) {
+	env := "env-1"
+	cluster := "cluster-1"
+	name := "test-connector"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		expectedPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/pause", env, cluster, name)
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: %s (expect %s)", r.URL.Path, expectedPath)
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	client := NewClient().WithAuth(noopAuth{}).WithBaseUrl(ts.URL)
+
+	err := client.PauseConnector(env, cluster, name)
+	assert.NoError(t, err)
+}
+
+func TestResumeConnector(t *testing.T) {
+	env := "env-1"
+	cluster := "cluster-1"
+	name := "test-connector"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		expectedPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/resume", env, cluster, name)
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: %s (expect %s)", r.URL.Path, expectedPath)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewClient().WithAuth(noopAuth{}).WithBaseUrl(ts.URL)
+
+	err := client.ResumeConnector(env, cluster, name)
+	assert.NoError(t, err)
+}
+
+func TestResumeConnectorAccepted(t *testing.T) {
+	env := "env-1"
+	cluster := "cluster-1"
+	name := "test-connector"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		expectedPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/resume", env, cluster, name)
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: %s (expect %s)", r.URL.Path, expectedPath)
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	client := NewClient().WithAuth(noopAuth{}).WithBaseUrl(ts.URL)
+
+	err := client.ResumeConnector(env, cluster, name)
+	assert.NoError(t, err)
+}
+
+func TestRestartConnector(t *testing.T) {
+	env := "env-1"
+	cluster := "cluster-1"
+	name := "test-connector"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		expectedPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/restart", env, cluster, name)
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: %s (expect %s)", r.URL.Path, expectedPath)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewClient().WithAuth(noopAuth{}).WithBaseUrl(ts.URL)
+
+	err := client.RestartConnector(env, cluster, name)
+	assert.NoError(t, err)
+}
+
+func TestRestartConnectorAccepted(t *testing.T) {
+	env := "env-1"
+	cluster := "cluster-1"
+	name := "test-connector"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		expectedPath := fmt.Sprintf("/connect/v1/environments/%s/clusters/%s/connectors/%s/restart", env, cluster, name)
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: %s (expect %s)", r.URL.Path, expectedPath)
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	client := NewClient().WithAuth(noopAuth{}).WithBaseUrl(ts.URL)
+
+	err := client.RestartConnector(env, cluster, name)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
# Summary

  Enhanced the connector management capabilities in the ccloud-client-go library by adding connector status monitoring and lifecycle
  control operations. This PR introduces new functions to pause, resume, and restart connectors, along with the ability to retrieve
  detailed connector status information.

  Changes Made

  1. New Data Types (connectors.go lines 59-76)

  Added three new structures to represent connector status information:

  - ConnectorStatus: Main status structure containing the connector name, overall connector status, and task statuses
    - Name: The connector name
    - Connector: ConnectorTaskStatus with state and worker ID
    - Tasks: Array of individual task statuses
  - ConnectorTaskStatus: Represents the status of the main connector process
    - State: Current state (e.g., "RUNNING", "PAUSED", "FAILED")
    - WorkerId: ID of the worker running the connector
    - Trace: Optional error trace information
  - TaskStatus: Represents individual task status
    - Id: Task identifier
    - State: Current task state
    - WorkerId: Worker ID executing the task
    - Trace: Optional error details

  2. New Functions (connectors.go lines 235-311)

  GetConnectorStatus (lines 235-255)
  - Retrieves the current status of a connector
  - Endpoint: GET /connect/v1/environments/{environment_id}/clusters/{kafka_cluster_id}/connectors/{connector_name}/status
  - Returns detailed status including connector and task states

  PauseConnector (lines 271-283)
  - Pauses a running connector
  - Endpoint: PUT /connect/v1/environments/{environment_id}/clusters/{kafka_cluster_id}/connectors/{connector_name}/pause
  - Accepts HTTP 200 (OK) and 202 (Accepted) responses

  ResumeConnector (lines 285-297)
  - Resumes a paused connector
  - Endpoint: PUT /connect/v1/environments/{environment_id}/clusters/{kafka_cluster_id}/connectors/{connector_name}/resume
  - Accepts HTTP 200 (OK) and 202 (Accepted) responses

  RestartConnector (lines 299-311)
  - Restarts a connector
  - Endpoint: POST /connect/v1/environments/{environment_id}/clusters/{kafka_cluster_id}/connectors/{connector_name}/restart
  - Accepts HTTP 200 (OK) and 202 (Accepted) responses

  3. Comprehensive Test Coverage (connectors_test.go lines 305-506)

  Added 7 new test functions:

  - TestGetConnectorStatus (lines 305-356): Validates status retrieval with complete status structure
  - TestPauseConnector (lines 358-381): Tests pause operation with HTTP 200 response
  - TestPauseConnectorAccepted (lines 383-406): Tests pause operation with HTTP 202 response
  - TestResumeConnector (lines 408-431): Tests resume operation with HTTP 200 response
  - TestResumeConnectorAccepted (lines 433-456): Tests resume operation with HTTP 202 response
  - TestRestartConnector (lines 458-481): Tests restart operation with HTTP 200 response
  - TestRestartConnectorAccepted (lines 483-506): Tests restart operation with HTTP 202 response

  4. Updated Documentation (README.md)

  - Added "Connector Management" to the Features list
  - Created new "Working with Connectors" section with subsections:
    - Creating a Connector
    - Managing Connector Lifecycle
    - Understanding Connector Status
  - Updated project description to mention connector management capabilities
  - Provided practical examples of all new functions

  API Compliance

  All implementations follow the Confluent Cloud Connect API v1 specification:
  - https://docs.confluent.io/cloud/current/api.html#tag/Lifecycle-(connectv1)
  - https://docs.confluent.io/cloud/current/api.html#tag/Status-(connectv1)

  Benefits

  1. Complete Lifecycle Management: Users can now fully control connector lifecycle (pause, resume, restart)
  2. Status Monitoring: Real-time connector and task status information
  3. Better Observability: Detailed status information helps diagnose connector issues
  4. Full Test Coverage: Comprehensive tests ensure reliability
  5. Clear Documentation: Examples and documentation help users adopt new features

  Testing

  All new functions include unit tests with mock HTTP servers:
  - Each test validates correct HTTP method (GET/PUT/POST)
  - Endpoint path validation
  - Response status code handling (200 and 202)
  - Response unmarshaling and structure validation
